### PR TITLE
Make mail module abide by user's notification settings

### DIFF
--- a/models/Message.php
+++ b/models/Message.php
@@ -179,9 +179,9 @@ class Message extends HActiveRecord
     {
 
         // User dont wants any emails
-        #if ($user->getSetting("receive_email_messaging", "core") == User::RECEIVE_EMAIL_NEVER) {
-        #    return;
-        #}
+        if ($user->getSetting("receive_email_messaging", "core") == User::RECEIVE_EMAIL_NEVER) {
+           return;
+        }
 
         $originatorName = $this->originator->displayName;
         $originatorGuid = $this->originator->guid;


### PR DESCRIPTION
Condition that checks to see if the user should be sent an email was commented out (causing users to receive an email regardless of their preferences)